### PR TITLE
Fix white-space property of textarea

### DIFF
--- a/css/reset.css
+++ b/css/reset.css
@@ -6,6 +6,11 @@
     display: revert;
 }
 
+/* revert the 'white-space' property for textarea elements on Safari */
+textarea {
+    white-space: revert;
+}
+
 /* Preferred box-sizing value */
 *,
 *::before,


### PR DESCRIPTION
## Fixed

When the` white-space` property of the `textarea` element is `unset`, setting a string that include a newline as value by JavaScript then, newlines to be converted to a spaces.

## Examples

```html
<p>
  <label>
    OK
    <textarea></textarea>
  </label>
</p>

<p>
  <label>
    NG
    <textarea style="white-space: unset;"></textarea>
  </label>
</p>

<script>
const value = `foo
baz

bar
`;

for (const textarea of document.querySelectorAll('textarea')) {
  textarea.value = value;
}
</script>
```