### PR TITLE
Add summary to items not reset

### DIFF
--- a/css/reset.css
+++ b/css/reset.css
@@ -4,7 +4,7 @@
     Remove all the styles of the "User-Agent-Stylesheet", except for the 'display' property
     - The "symbol *" part is to solve Firefox SVG sprite bug
  */
-*:where(:not(iframe, canvas, img, svg, video):not(svg *, symbol *)) {
+*:where(:not(iframe, canvas, img, svg, video, summary):not(svg *, symbol *)) {
     all: unset;
     display: revert;
 }


### PR DESCRIPTION
This PR adds `summary` to the list of items not reset.

The reason is that, by resetting it, the icon accompanying the `summary` in a `details` drop-down changes from an arrow, which usefully changes direction according to whether `details` is open or closed, to a bullet, which provides no such information and is essentially meaningless in this context anyway.

This PR thus has the effect of retaining the arrow.