### PR TITLE
<menu> also has list style in Safari

### DIFF
--- a/css/reset.css
+++ b/css/reset.css
@@ -17,7 +17,7 @@
 }
 
 /* Remove list styles (bullets/numbers) */
-ol, ul {
+ol, ul, menu {
     list-style: none;
 }
 


### PR DESCRIPTION
Safari has default list styles for `<menu>`, so accounting for those here. See before and after screenshots:

```html
<h1>UL</h1>
<ul>
    <li>Item</li>
    <li>Item</li>
</ul>

<h1>menu</h1>
<menu>
    <li>Item</li>
    <li>Item</li>
</menu>
```

Before:
<img width="57" alt="before" src="https://user-images.githubusercontent.com/294565/143309478-ebafcf91-dd3b-4d42-91d3-7b84e385ba40.png">

After:
<img width="48" alt="after" src="https://user-images.githubusercontent.com/294565/143309487-410c5ead-a407-42dc-affe-dd087adb886d.png">

