### PR TITLE
Reapply the pointer cursor for anchor tags

### DIFF
--- a/css/reset.css
+++ b/css/reset.css
@@ -16,6 +16,11 @@
     box-sizing: border-box;
 }
 
+/* Reapply the pointer cursor for anchor tags */
+a {
+    cursor: revert;
+}
+
 /* Remove list styles (bullets/numbers) */
 ol, ul, menu {
     list-style: none;


### PR DESCRIPTION
Seeing as box-sizing is defined and set based on the general opinion of "Preferred box-sizing value", I'd argue reverting the cursor for anchor tags should be done as well. Pointer cursors are deeply ingrained in the way we perceive nav links and navigating without it just feels unnatural. I'd consider the absence of a pointer to be an accessibility issue, even though it is not mentioned in the WCAG. The W3CWD however, has [additional specification](https://www.w3.org/TR/css-ui-4/#cursor) to the pointer cursor, stating `Authors should use pointer on links and may use on other interactive elements`.