### PR TITLE
Added clarification on why the html element is excluded

### DIFF
--- a/css/reset.css
+++ b/css/reset.css
@@ -1,11 +1,12 @@
 /***
-    The new CSS reset - version 1.8.2 (last updated 23.12.2022)
+    The new CSS reset - version 1.8.3 (last updated 16.01.2023)
     GitHub page: https://github.com/elad2412/the-new-css-reset
 ***/
 
 /*
     Remove all the styles of the "User-Agent-Stylesheet", except for the 'display' property
     - The "symbol *" part is to solve Firefox SVG sprite bug
+    - The "html" attribute is exluded, because otherwise a bug in Chrome breaks the CSS hyphens property
  */
 *:where(:not(html, iframe, canvas, img, svg, video, audio):not(svg *, symbol *)) {
     all: unset;

--- a/css/reset.css
+++ b/css/reset.css
@@ -6,7 +6,7 @@
 /*
     Remove all the styles of the "User-Agent-Stylesheet", except for the 'display' property
     - The "symbol *" part is to solve Firefox SVG sprite bug
-    - The "html" attribute is exluded, because otherwise a bug in Chrome breaks the CSS hyphens property
+    - The "html" attribute is exluded, because otherwise a bug in Chrome breaks the CSS hyphens property (https://github.com/elad2412/the-new-css-reset/issues/36)
  */
 *:where(:not(html, iframe, canvas, img, svg, video, audio):not(svg *, symbol *)) {
     all: unset;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-new-css-reset",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "description": "the new CSS reset, using new css features",
   "main": "css/reset.css",
   "scripts": {


### PR DESCRIPTION
When resetting a specific element causes a bug, and that reset is reverted because of that, the new CSS reset explains that in almost every case, however, it wasn't clear that the html element was excluded from the reset because of a bug, so I added a line in the comment clarifying the reason for its exclusion.