### PR TITLE
Fixed a typo in reset.css

### DIFF
--- a/css/reset.css
+++ b/css/reset.css
@@ -7,7 +7,7 @@
 /*
     Remove all the styles of the "User-Agent-Stylesheet", except for the 'display' property
     - The "symbol *" part is to solve Firefox SVG sprite bug
-    - The "html" attribute is exclud, because otherwise a bug in Chrome breaks the CSS hyphens property (https://github.com/elad2412/the-new-css-reset/issues/36)
+    - The "html" element is exclud, because otherwise a bug in Chrome breaks the CSS hyphens property (https://github.com/elad2412/the-new-css-reset/issues/36)
  */
 *:where(:not(html, iframe, canvas, img, svg, video, audio):not(svg *, symbol *)) {
     all: unset;


### PR DESCRIPTION
Fixed a typo in reset css, where during a previous pull request I've added clarification on the exclusion of the html element. However, in that clarification I said the 'html attribute' instead of the 'html element'