### PR TITLE
Make sure pre and modal keep border-box sizing.

### DIFF
--- a/css/reset.css
+++ b/css/reset.css
@@ -13,6 +13,16 @@
     display: revert;
 }
 
+/* preformatted text - use only for this feature */
+:where(pre) {
+    all: revert;
+}
+
+/* Revert Modal native behavior */
+:where(dialog:modal) {
+    all: revert;
+}
+
 /* Preferred box-sizing value */
 *,
 *::before,
@@ -57,11 +67,6 @@ meter {
     appearance: revert;
 }
 
-/* preformatted text - use only for this feature */
-:where(pre) {
-    all: revert;
-}
-
 /* reset default text opacity of input placeholder */
 ::placeholder {
     color: unset;
@@ -92,9 +97,4 @@ meter {
 /* apply back the draggable feature - exist only in Chromium and Safari */
 :where([draggable="true"]) {
     -webkit-user-drag: element;
-}
-
-/* Revert Modal native behavior */
-:where(dialog:modal) {
-    all: revert;
 }


### PR DESCRIPTION
This makes sure that

```css
*,
*::before,
*::after {
    box-sizing: border-box;
}
```

applies properly to `pre` and `dialog:modal`.